### PR TITLE
modify yaneuraou

### DIFF
--- a/Formula/yaneuraou.rb
+++ b/Formula/yaneuraou.rb
@@ -4,56 +4,43 @@
 class Yaneuraou < Formula
   desc "YaneuraOu is the World's Strongest Shogi engine(AI player) , WCSC29 1st winner , educational and USI compliant engine."
   homepage "http://yaneuraou.yaneu.com"
-  url "https://github.com/yaneurao/YaneuraOu/archive/V4.88.tar.gz"
-  version "4.88"
-  sha256 "a55b139290451777db20b41dd90b86f15c8600f7f991e8740b38e0b7debac5e0"
+  url "https://github.com/yaneurao/YaneuraOu/archive/V4.91.tar.gz"
+  version "4.91"
+  sha256 "db13f249d55aa8a5a0c75d4fccb8750446345dd937f4c2cf1326341bf53a84d5"
 
   depends_on "gnu-sed"
 
   def install
     # ENV.deparallelize  # if your formula fails when building in parallel
 
-    system "gsed -i -e \"s,#define USE_AVX2,//#define USE_AVX2,\" source/config.h"
-    system "gsed -i -e \"s,//#define NO_SSE,#define NO_SSE,\" source/config.h" if Hardware::CPU.is_32_bit?
-    system "gsed -i -e \"s,//#define USE_SSE2,#define USE_SSE2,\" source/config.h" if Hardware::CPU.is_64_bit?
-    system "gsed -i -e \"s,//#define USE_SSE41,#define USE_SSE41,\" -e \"s,#define USE_SSE2,//#define USE_SSE2,\" source/config.h" if Hardware::CPU.sse4?
-    system "gsed -i -e \"s,//#define USE_SSE42,#define USE_SSE42,\" -e \"s,#define USE_SSE41,//#define USE_SSE41,\" source/config.h" if Hardware::CPU.sse4_2?
-    system "gsed -i -e \"s,//#define USE_AVX2,#define USE_AVX2,\" -e \"s,#define USE_SSE42,//#define USE_SSE42,\" source/config.h" if Hardware::CPU.avx2?
+    system "gsed -i -e \"s,CFLAGS += -stdlib=libstdc++,CFLAGS += -stdlib=libc++,\" source/Makefile"
+    if Hardware::CPU.is_32_bit? then
+      target_cpu_list = ['NO_SSE']
+    else 
+      target_cpu_list = ['AVX2', 'SSE42', 'SSE41', 'SSE2', 'OTHER']
+    end
 
-    system "gsed -i -e \"s,#COMPILER = g++,COMPILER = g++,\" -e \"s,COMPILER = clang++,#COMPILER = clang++,\" source/Makefile"
+    target_cpu_list.each do |target_cpu|
+      system "make -C source clean"
+      system "make -C source TARGET_CPU=#{target_cpu} YANEURAOU_EDITION=YANEURAOU_ENGINE_NNUE"
+      system "mv source/YaneuraOu-by-gcc YaneuraOu_NNUE"
+      begin
+        system "echo 'usi' | ./YaneuraOu_NNUE | grep 'usiok'"
 
-    system "gsed -i -e \"s,TARGET_CPU = AVX2,#TARGET_CPU = AVX2,\" source/Makefile"
-    system "gsed -i -e \"s,#TARGET_CPU = NO_SSE,TARGET_CPU = NO_SSE,\" source/Makefile" if Hardware::CPU.is_32_bit?
-    system "gsed -i -e \"s,#TARGET_CPU = SSE2,TARGET_CPU = SSE2,\" source/Makefile" if Hardware::CPU.is_64_bit?
-    system "gsed -i -e \"s,#TARGET_CPU = SSE41,TARGET_CPU = SSE41,\" -e \"s,TARGET_CPU = SSE2,#TARGET_CPU = SSE2,\" source/Makefile" if Hardware::CPU.sse4?
-    system "gsed -i -e \"s,#TARGET_CPU = SSE42,TARGET_CPU = SSE42,\" -e \"s,TARGET_CPU = SSE41,#TARGET_CPU = SSE41,\" source/Makefile" if Hardware::CPU.sse4_2?
-    system "gsed -i -e \"s,#TARGET_CPU = AVX2,TARGET_CPU = AVX2,\" -e \"s,TARGET_CPU = SSE42,#TARGET_CPU = SSE42,\" source/Makefile" if Hardware::CPU.avx2?
+        system "make -C source clean"
+        system "make -C source TARGET_CPU=#{target_cpu} YANEURAOU_EDITION=YANEURAOU_ENGINE_NNUE_KP256"
+        system "mv source/YaneuraOu-by-gcc YaneuraOu_NNUE_KP256"
 
-    system "make -C source"
-    system "mv source/YaneuraOu-by-gcc YaneuraOu_NNUE"
-
-    system "gsed -i -e \"s,YANEURAOU_EDITION = YANEURAOU_ENGINE_NNUE,#YANEURAOU_EDITION = YANEURAOU_ENGINE_NNUE,\" -e \"s,##YANEURAOU_EDITION = YANEURAOU_ENGINE_NNUE_KP256,YANEURAOU_EDITION = YANEURAOU_ENGINE_NNUE_KP256,\" source/Makefile"
-    system "make clean -C source"
-    system "make -C source"
-    system "mv source/YaneuraOu-by-gcc YaneuraOu_NNUE_KP256"
-
-    system "gsed -i -e \"s,YANEURAOU_EDITION = YANEURAOU_ENGINE_NNUE_KP256,#YANEURAOU_EDITION = YANEURAOU_ENGINE_NNUE_KP256,\" -e \"s,#YANEURAOU_EDITION = YANEURAOU_ENGINE_KPPT,YANEURAOU_EDITION = YANEURAOU_ENGINE_KPPT,\" source/Makefile"
-    system "make clean -C source"
-    system "make -C source"
-    system "mv source/YaneuraOu-by-gcc YaneuraOu_KPPT"
-
-    system "gsed -i -e \"s,YANEURAOU_EDITION = YANEURAOU_ENGINE_KPPT,#YANEURAOU_EDITION = YANEURAOU_ENGINE_KPPT,\" -e \"s,#YANEURAOU_EDITION = YANEURAOU_ENGINE_KPP_KKPT,YANEURAOU_EDITION = YANEURAOU_ENGINE_KPP_KKPT,\" source/Makefile"
-    system "make clean -C source"
-    system "make -C source"
-    system "mv source/YaneuraOu-by-gcc YaneuraOu_KPP_KKPT"
-
-    prefix.install "YaneuraOu_NNUE", "YaneuraOu_NNUE_KP256", "YaneuraOu_KPPT", "YaneuraOu_KPP_KKPT"
+        prefix.install "YaneuraOu_NNUE", "YaneuraOu_NNUE_KP256"
+        return
+      rescue
+      end
+    end
+    raise "Can't Install"
   end
 
   test do
     assert_match 'usiok', shell_output("cd #{prefix} && echo 'usi' | ./YaneuraOu_NNUE | grep 'usiok'")
     assert_match 'usiok', shell_output("cd #{prefix} && echo 'usi' | ./YaneuraOu_NNUE_KP256 | grep 'usiok'")
-    assert_match 'usiok', shell_output("cd #{prefix} && echo 'usi' | ./YaneuraOu_KPPT | grep 'usiok'")
-    assert_match 'usiok', shell_output("cd #{prefix} && echo 'usi' | ./YaneuraOu_KPP_KKPT | grep 'usiok'")
   end
 end


### PR DESCRIPTION
素晴らしい Fomulaをありがとうございます。

私の環境 `MacBook Pro (Retina, 13-inch, Early 2015), 3.1 GHz デュアルコアIntel Core i7` だと、
yaneuraou が build は通るのですが、実行時にsegmentation fault になってしまっていました。

原因を調べてみると、どうも `Hardware::CPU.avx2?` は `true` なのに、`TARGET_CPU=AVX2` だとだめみたいでした。

確かにPCとしては

- `sysctl hw.optional.avx2_0` -> `1`
- `sysctl -a | grep machdep | grep features` -> `AVX2` がある

とサポートしているようなのですが、MakefileのOptionが何か不適切なのかどうしても治らない…

ので、場当たり的ではありますが、 「build して 実行したときにエラーになったら次のtarget_cpuでbuildしてみる」 というように変えてみました。

私の環境では、elmo も uonuma-yaneuraou もこれで動きました。

clangでbuildして、今回ので使っていないEditionはbuildしていませんし、
ちょっと微妙な修正ではありますので、取り込んでもらわない方がいいかもしれないです。
が、もしよろしければ 参考 or 反映して頂けると幸いです。