### PR TITLE
将棋ぶらうざQを追加する

### DIFF
--- a/Casks/sbrowserq.rb
+++ b/Casks/sbrowserq.rb
@@ -5,7 +5,7 @@ cask "sbrowserq" do
   sha256 "8952a2095efc2f658c0dc03cee7a5c77a1ab07bdd4186a089826665b13a4227e"
 
   url "https://www.sbrowser-q.com/SBrowserQ_V#{version_without_patch}_mac.dmg"
-  name "sbrowserq"
+  name "将棋ぶらうざQ"
   desc "Shogi game playing and game record management"
   homepage "https://www.sbrowser-q.com/"
 
@@ -15,5 +15,5 @@ cask "sbrowserq" do
     regex(/V(\d\.\d\.\d)/)
   end
 
-  app "SBrowserQ.app"
+  suite ".", target: name.first
 end

--- a/Casks/sbrowserq.rb
+++ b/Casks/sbrowserq.rb
@@ -1,0 +1,19 @@
+cask "sbrowserq" do
+  version_without_patch = "3.7"
+
+  version "#{version_without_patch}.4"
+  sha256 "8952a2095efc2f658c0dc03cee7a5c77a1ab07bdd4186a089826665b13a4227e"
+
+  url "https://www.sbrowser-q.com/SBrowserQ_V#{version_without_patch}_mac.dmg"
+  name "sbrowserq"
+  desc "Shogi game playing and game record management"
+  homepage "https://www.sbrowser-q.com/"
+
+  livecheck do
+    url :homepage
+    strategy :page_match
+    regex(/V(\d\.\d\.\d)/)
+  end
+
+  app "SBrowserQ.app"
+end

--- a/Casks/sbrowserq.rb
+++ b/Casks/sbrowserq.rb
@@ -5,8 +5,8 @@ cask "sbrowserq" do
   sha256 "8952a2095efc2f658c0dc03cee7a5c77a1ab07bdd4186a089826665b13a4227e"
 
   url "https://www.sbrowser-q.com/SBrowserQ_V#{version_without_patch}_mac.dmg"
-  name "将棋ぶらうざQ"
-  desc "Shogi game playing and game record management"
+  name "SBrowserQ"
+  desc "Software for shogi playing a game and management a game record"
   homepage "https://www.sbrowser-q.com/"
 
   livecheck do


### PR DESCRIPTION
[将棋ぶらうざQ](https://www.sbrowser-q.com/)をHomebrew Caskによりインストールできるようにする変更です。
（もし将棋エンジン以外を受け付けていないようであればすみません。）

- [x] 付属のファイルを `/Applications/SBrowserQ/` 以下に追加する。（現状`SBrowserQ.app`のみ追加される。）
- [x] 必要最低限の依存関係を設定する → Javaはおそらくアプリ自体に組込まれていると考えてよさそうです。
- [-] (wontfix) LaunchPadにアプリのアイコンが表示されるようにする。

## 参考

* [Cask Cookbook](https://docs.brew.sh/Cask-Cookbook)
* homebrew-casksにも一時期入っていましたが、ダウンロード数が少なかったため削除されました。
  * 追加されたプルリクエスト： Homebrew/homebrew-cask#8401
  * 削除されたコミット： [Analytics cask purge](https://github.com/Homebrew/homebrew-cask/commit/25a1054b3866288987ef17d10377de56054aee48)